### PR TITLE
Feature/smooth progress bars

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -190,23 +190,21 @@ export class ShadingScene {
     // Compute unique intensities
     console.log('Calling this.rayTrace');
 
+    const doDiffuseIntensities = typeof diffuseIrradianceURL === 'string';
+    const simulationRounds = doDiffuseIntensities ? 2 : 1;
+
     const directIntensities = await this.rayTrace(
       midpointsArray,
       normalsArray,
       meshArray,
       numberSimulations,
       undefined,
-      progressCallback,
+      (i, total) => progressCallback(i, total * simulationRounds),
     );
     let diffuseIntensities = new Float32Array();
-    if (typeof diffuseIrradianceURL === 'string') {
-      diffuseIntensities = await this.rayTrace(
-        midpointsArray,
-        normalsArray,
-        meshArray,
-        0,
-        diffuseIrradianceURL,
-        progressCallback,
+    if (doDiffuseIntensities) {
+      diffuseIntensities = await this.rayTrace(midpointsArray, normalsArray, meshArray, 0, diffuseIrradianceURL, (i, total) =>
+        progressCallback(i + total, total * simulationRounds),
       );
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,7 +298,7 @@ export class ShadingScene {
       sun.shadeIrradianceFromElevation(irradiance, shadingElevationAngles);
     }
     normals = normals.filter((_, index) => index % 9 < 3);
-    let intensities = rayTracingWebGL(midpoints, normals, meshArray, irradiance, progressCallback);
+    let intensities = await rayTracingWebGL(midpoints, normals, meshArray, irradiance, progressCallback);
 
     if (intensities === null) {
       throw new Error('Error occured when running the Raytracing in WebGL.');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,3 +112,22 @@ export interface CalculateParams {
   urlDiffuseIrrandianceTIF?: string;
   progressCallback?: (progress: number, total: number) => void;
 }
+
+/**
+ * Mimics a for-loop but schedules each loop iteration using `setTimeout`, so that
+ * event handles, react updates, etc. can run in-between
+ */
+export async function timeoutForLoop(start: number, end: number, body: (i: number) => void) {
+  return new Promise<void>((resolve) => {
+    const inner = (i: number) => {
+      body(i);
+      i = i + 1;
+      if (i == end) {
+        resolve();
+      } else {
+        setTimeout(() => inner(i), 0);
+      }
+    };
+    setTimeout(() => inner(0), 0);
+  });
+}


### PR DESCRIPTION
Use `setTimeout` to stop blocking the main thread during our calculation iteration.

Also, this now internally wraps the `progressCallback` function in case two iterations rounds are done (= if diffuseRadiation is computed), in order to stop the progress bar from jumping all over the place.