### PR TITLE
64 headless simshady

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
   "dependencies": {
     "geotiff": "^2.1.3",
     "three": "^0.175.0",
-    "gl": "^8.1.6"
+    "gl": "^8.1.6",
+    "puppeteer": "^24.20.0",
+    "tsx": "^4.20.5"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   },
   "dependencies": {
     "geotiff": "^2.1.3",
-    "three": "^0.175.0"
+    "three": "^0.175.0",
+    "gl": "^8.1.6"
   },
   "lint-staged": {
     "*.js": [

--- a/src/headless/createHeadlessGL.ts
+++ b/src/headless/createHeadlessGL.ts
@@ -1,0 +1,58 @@
+/**
+ * Configuration options for headless WebGL context
+ */
+export interface HeadlessGLOptions {
+  width?: number;
+  height?: number;
+  createWebGL2Context?: boolean;
+  preserveDrawingBuffer?: boolean;
+  antialias?: boolean;
+  alpha?: boolean;
+  depth?: boolean;
+  stencil?: boolean;
+  premultipliedAlpha?: boolean;
+}
+
+/**
+ * Creates a headless WebGL context using headless-gl
+ * Note: headless-gl currently only supports WebGL 2.0 in on an experimental level
+ *
+ * @param options Configuration options for the WebGL context
+ * @returns WebGL context that can be used with simshady's ray tracing functions
+ */
+export async function createHeadlessGL(options: HeadlessGLOptions = {}): Promise<WebGLRenderingContext> {
+  try {
+    const { default: createGL } = await import('gl');
+
+    const {
+      width = 100,
+      height = 100,
+      createWebGL2Context = true,
+      preserveDrawingBuffer = true,
+      antialias = false,
+      alpha = false,
+      depth = true,
+      stencil = false,
+      premultipliedAlpha = true,
+    } = options;
+
+    // Create the headless WebGL context
+    const gl = createGL(width, height, {
+      createWebGL2Context,
+      preserveDrawingBuffer,
+      antialias,
+      alpha,
+      depth,
+      stencil,
+      premultipliedAlpha,
+    });
+
+    if (!gl) {
+      throw new Error('Failed to create headless WebGL context');
+    }
+
+    return gl as WebGLRenderingContext;
+  } catch (error) {
+    throw new Error(`Failed to create headless WebGL context. ${error}`);
+  }
+}

--- a/src/headless/headlessBrowser.d.ts
+++ b/src/headless/headlessBrowser.d.ts
@@ -1,0 +1,20 @@
+import type { SolarIrradianceData } from '../utils';
+export interface RunHeadlessChromiumOptions {
+  returnColors?: boolean;
+  launchArgs?: string[];
+  executablePath?: string;
+}
+
+export interface RunHeadlessChromiumResult {
+  intensities: number[];
+  colors?: number[];
+}
+
+export function runShadingSceneHeadlessChromium(
+  simulationPositions: Float32Array | number[],
+  shadingPositions: Float32Array | number[],
+  solarIrradiance: SolarIrradianceData,
+  solarToElectricityConversionEfficiency?: number,
+  maxYieldPerSquareMeter?: number,
+  options?: RunHeadlessChromiumOptions,
+): Promise<RunHeadlessChromiumResult>;

--- a/src/headless/headlessBrowser.js
+++ b/src/headless/headlessBrowser.js
@@ -1,0 +1,135 @@
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Run ShadingScene in headless Chromium with WebGL2 enabled.
+ */
+export async function runShadingSceneHeadlessChromium(
+  simulationPositions,
+  shadingPositions,
+  solarIrradiance,
+  solarToElectricityConversionEfficiency,
+  maxYieldPerSquareMeter,
+  options = {},
+) {
+  const { returnColors = false, launchArgs = [], executablePath } = options;
+  const browser = await puppeteer
+    .launch({
+      args: ['--headless=new', '--enable-webgl2', '--no-sandbox', ...launchArgs],
+      executablePath,
+    })
+    .catch((error) => {
+      throw new Error(`Failed to launch Puppeteer browser: ${error.message}`);
+    });
+  try {
+    const page = await browser.newPage();
+    try {
+      await page.setContent(
+        `
+              <!doctype html>
+              <meta charset="utf-8" />
+              <script type="importmap">
+              {
+                "imports": {
+                  "three": "https://unpkg.com/three@0.161.0/build/three.module.js",
+                  "three/examples/jsm/utils/BufferGeometryUtils.js": "https://unpkg.com/three@0.161.0/examples/jsm/utils/BufferGeometryUtils.js"
+                }
+              }
+              </script>
+              <body></body>`.trim(),
+        { waitUntil: 'domcontentloaded', timeout: 30000 },
+      );
+    } catch (error) {
+      throw new Error(`Failed to set page content: ${error.message}`);
+    }
+
+    const hasWebGL2 = await page.evaluate(() => !!document.createElement('canvas').getContext('webgl2'));
+    if (!hasWebGL2) {
+      throw new Error('WebGL2 not available in headless Chromium.');
+    }
+    const bundlePath = path.resolve(__dirname, '../../dist/index.js');
+    if (!fs.existsSync(bundlePath)) {
+      throw new Error(`Bundle not found at ${bundlePath}. Please run 'yarn build' first.`);
+    }
+    const simshadyBundle = fs.readFileSync(bundlePath, 'utf8');
+    let result;
+    try {
+      result = await page.evaluate(
+        async ({
+          simshadyBundle,
+          sim,
+          shade,
+          irr,
+          solarToElectricityConversionEfficiency,
+          maxYieldPerSquareMeter,
+          wantColors,
+        }) => {
+          try {
+            const blob = new Blob([simshadyBundle], { type: 'text/javascript' });
+            const url = URL.createObjectURL(blob);
+
+            // needed for successful testing using vitest
+            const dynamicImport = (0, eval)('u => import(u)');
+
+            const { ShadingScene } = await dynamicImport(url);
+            const { BufferGeometry, Float32BufferAttribute } = await dynamicImport('three');
+
+            function fromArrays(pos) {
+              const positions = new Float32Array(pos);
+              if (positions.length % 9 !== 0) throw new Error('Triangle array length must be divisible by 9.');
+              const geom = new BufferGeometry();
+              geom.setAttribute('position', new Float32BufferAttribute(positions, 3));
+              return geom;
+            }
+
+            const simGeom = fromArrays(sim);
+            const shadeGeom = fromArrays(shade);
+            const scene = new ShadingScene();
+            scene.addSimulationGeometry(simGeom);
+            scene.addShadingGeometry(shadeGeom);
+            scene.addSolarIrradiance(irr);
+
+            const mesh = await scene.calculate({ solarToElectricityConversionEfficiency, maxYieldPerSquareMeter });
+
+            const intensitiesAttr = mesh.geometry.getAttribute('intensities');
+            const intensities = Array.from(intensitiesAttr.array);
+            const out = { intensities };
+            if (wantColors) {
+              const colorAttr = mesh.geometry.getAttribute('color');
+              if (colorAttr) {
+                out.colors = Array.from(colorAttr.array);
+              }
+            }
+            return out;
+          } catch (error) {
+            // return error here so it can get handled outside the browser context
+            return { error: error.message, stack: error.stack };
+          }
+        },
+        {
+          simshadyBundle: simshadyBundle,
+          sim: Array.from(simulationPositions),
+          shade: Array.from(shadingPositions),
+          solarToElectricityConversionEfficiency,
+          maxYieldPerSquareMeter,
+          irr: solarIrradiance,
+          wantColors: returnColors,
+        },
+      );
+      // Check if there was an error in the page evaluation
+      if (result && typeof result === 'object' && 'error' in result) {
+        throw new Error(`Error in browser evaluation: ${result.error}`);
+      }
+    } catch (error) {
+      throw new Error(`Failed to execute shading calculation in browser: ${error.message}`);
+    }
+    return result;
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/headless/headlessShadingScene.ts
+++ b/src/headless/headlessShadingScene.ts
@@ -1,0 +1,76 @@
+import { TypedArray } from 'three';
+import { SolarIrradianceData } from '../utils.js';
+
+import { createHeadlessGL, HeadlessGLOptions } from './createHeadlessGL';
+import { ShadingScene } from '../main';
+
+/**
+ * Headless version of {@link ShadingScene}.
+ *
+ * This class provides the same functionality as ShadingScene but is made for running in
+ * Node.js environments using headless WebGL rendering.
+ */
+export class HeadlessShadingScene extends ShadingScene {
+  /** Optional WebGL context for headless rendering */
+  private glContext?: WebGLRenderingContext | WebGL2RenderingContext;
+  private readonly glOptions?: HeadlessGLOptions;
+
+  constructor(glOptions?: HeadlessGLOptions) {
+    super();
+    this.glOptions = glOptions;
+  }
+
+  /**
+   * Sets a custom WebGL context for headless rendering
+   * @param gl WebGL context to use (WebGL1 or WebGL2)
+   */
+  setWebGLContext(gl: WebGLRenderingContext | WebGL2RenderingContext) {
+    this.glContext = gl;
+  }
+
+  /**
+   * Creates or returns the WebGL context for headless rendering
+   */
+  private async getWebGLContext(): Promise<WebGLRenderingContext | WebGL2RenderingContext> {
+    if (!this.glContext) {
+      this.glContext = await createHeadlessGL(this.glOptions);
+    }
+    return this.glContext;
+  }
+
+  /**
+   * This function returns a time series of intensities of shape T x N, with N the number of midpoints.
+   * It includes the shading of geometries, the dot product of normal vector and sky segment vector,
+   * and the radiation values from diffuse and direct irradiance.
+   *
+   * @param midpoints midpoints of triangles for which to calculate intensities
+   * @param normals normals for each midpoint
+   * @param meshArray array of vertices for the shading mesh
+   * @param irradiance Time Series of sky domes
+   * @return
+   */
+  protected async rayTrace(
+    midpoints: Float32Array,
+    normals: TypedArray,
+    meshArray: Float32Array,
+    irradiance: SolarIrradianceData[],
+    progressCallback: (progress: number, total: number) => void,
+  ): Promise<Float32Array[]> {
+    // Use the headless WebGL context for ray tracing
+    const gl = await this.getWebGLContext();
+
+    return super.rayTrace(midpoints, normals, meshArray, irradiance, progressCallback, gl);
+  }
+
+  /**
+   * Cleanup resources when done
+   */
+  dispose() {
+    if (this.glContext && this.glContext.getExtension) {
+      const destroyExt = this.glContext.getExtension('STACKGL_destroy_context');
+      if (destroyExt) {
+        destroyExt.destroy();
+      }
+    }
+  }
+}

--- a/src/headless/rayTracingWebGL1Headless.ts
+++ b/src/headless/rayTracingWebGL1Headless.ts
@@ -1,0 +1,340 @@
+import { TypedArray } from 'three';
+import { timeoutForLoop } from '../utils';
+
+/**
+ * WebGL1-compatible version of rayTracingWebGL that accepts a WebGL context as parameter
+ * This version uses WebGL1 features for compatibility with headless-gl.
+ *
+ * @param midpointsArray flattened Nx3 array with N the number of surface points for which shading is calculated
+ * @param normals flattened Nx3 array, N times a vector of 3 components (the midpoint normals)
+ * @param trianglesArray flattened Mx9 array with M the number of shading triangles
+ * @param skysegmentDirectionArray flattened Sx3 array with S being the number of sky segments (normalized!)
+ * @param progressCallback flattened Callback indicating the progress
+ * @param gl WebGL1 context to use for rendering
+ * @returns shadedMaskScenes: NxS array containing the dot product of the direction vector of the skysegment and the normal of the midpoint
+ */
+export async function rayTracingWebGL1Headless(
+  midpointsArray: TypedArray,
+  normals: TypedArray,
+  trianglesArray: TypedArray,
+  skysegmentDirectionArray: Float32Array,
+  progressCallback: (progress: number, total: number) => void,
+  gl: WebGLRenderingContext,
+): Promise<Float32Array[] | null> {
+  const N_TRIANGLES = trianglesArray.length / 9;
+  const width = midpointsArray.length / 3; // Change this to the number of horizontal points in the grid
+  const N_POINTS = width;
+
+  const textureFloatExtension = gl.getExtension('OES_texture_float');
+  if (!textureFloatExtension) {
+    throw Error(`OES_texture_float not available!`);
+  }
+
+  // Vertex shader code (fullscreen triangle)
+  const vertexShaderSource = `
+        precision highp float;
+        attribute vec2 a_position;
+        void main() {
+            gl_Position = vec4(a_position, 0.0, 1.0);
+        }
+        `;
+
+  // Fragment shader code
+  const fragmentShaderSource = `
+        #define INFINITY         1000000.0
+        precision highp float;
+
+        uniform sampler2D u_triangles;
+        uniform vec3 u_sun_direction;
+        uniform float textureWidth;
+        uniform float textureHeight;
+
+        uniform sampler2D u_midpoints;
+        uniform sampler2D u_normals;
+        uniform float u_pointsWidth;
+
+
+        vec3 cross1(vec3 a, vec3 b) {
+            vec3 c = vec3(0, 0, 0);
+            c.x = a[1] * b[2] - a[2] * b[1];
+            c.y = a[2] * b[0] - a[0] * b[2];
+            c.z = a[0] * b[1] - a[1] * b[0];
+            return c;
+        }
+
+        float TriangleIntersect( vec3 v0, vec3 v1, vec3 v2, vec3 rayOrigin, vec3 rayDirection, int isDoubleSided )
+        {
+            vec3 edge1 = v1 - v0;
+            vec3 edge2 = v2 - v0;
+
+            vec3 pvec = cross1(rayDirection, edge2);
+
+            float epsilon = 0.000001; // Add epsilon to avoid division by zero
+            float det = dot(edge1, pvec);
+            if (abs(det) < epsilon) // Check if det is too close to zero
+                return INFINITY;
+
+            float inv_det = 1.0 / det;
+            if ( isDoubleSided == 0 && det < 0.0 ) 
+                return INFINITY;
+
+            vec3 tvec = rayOrigin - v0;
+            float u = dot(tvec, pvec) * inv_det;
+            vec3 qvec = cross1(tvec, edge1);
+            float v = dot(rayDirection, qvec) * inv_det;
+            float t = dot(edge2, qvec) * inv_det;
+            return (u < 0.0 || u > 1.0 || v < 0.0 || u + v > 1.0 || t <= 0.01) ? INFINITY : t;
+
+        }
+
+        vec3 getTriangleVertexPosition(int triIndex, int vertexIndex) {
+            int dataIndex = triIndex * 3 + vertexIndex;
+            // normalized uv floats
+            float fx = mod(float(dataIndex), textureWidth);
+            float fy = floor(float(dataIndex) / textureWidth);
+            vec2 uv = vec2((fx + 0.5) / textureWidth, (fy + 0.5) / textureHeight);
+            return texture2D(u_triangles, uv).rgb;
+        }
+
+        bool Calculate_Shading_at_Point(vec3 vertex_position, vec3 sun_direction) {
+            float d;
+            float t = INFINITY;
+            for (int i = 0; i < ${N_TRIANGLES}; i++) {
+                vec3 v0 = getTriangleVertexPosition(i, 0);
+                vec3 v1 = getTriangleVertexPosition(i, 1);
+                vec3 v2 = getTriangleVertexPosition(i, 2);
+                d = TriangleIntersect(v0, v1, v2, vertex_position, sun_direction, 1);
+                if (d < t && abs(d)>0.0001) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void main() {
+            // Map current fragment to midpoint index
+            float x = gl_FragCoord.x / u_pointsWidth;
+            vec3 pos = texture2D(u_midpoints, vec2(x, 0.5)).rgb;
+            vec3 nrm = texture2D(u_normals, vec2(x, 0.5)).rgb;
+
+            float intensity = 0.0;
+            if (!Calculate_Shading_at_Point(pos, u_sun_direction)) {
+                intensity = abs(dot(normalize(nrm), u_sun_direction));
+            }
+            gl_FragColor = vec4(intensity, intensity, intensity, intensity);
+        }
+        `;
+
+  const vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
+  const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource);
+
+  const program = createProgram(gl, vertexShader, fragmentShader);
+
+  const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+
+  const textureWidth = Math.min(3 * N_TRIANGLES, Math.floor(maxTextureSize / 9) * 9);
+  const textureHeight = Math.ceil((3 * N_TRIANGLES) / textureWidth);
+
+  gl.useProgram(program);
+
+  // Triangles texture
+  const texture = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+
+  let alignedTrianglesArray;
+  if (textureHeight == 1) {
+    alignedTrianglesArray = trianglesArray;
+  } else {
+    alignedTrianglesArray = new Float32Array(textureWidth * textureHeight * 3);
+
+    for (let i = 0; i < 3 * N_TRIANGLES; i++) {
+      const x = (3 * i) % textureWidth;
+      const y = Math.floor((3 * i) / textureWidth);
+      const index = y * textureWidth + x;
+      for (let j = 0; j < 3; j++) {
+        alignedTrianglesArray[index + j] = trianglesArray[3 * i + j];
+      }
+    }
+  }
+
+  gl.texImage2D(
+    gl.TEXTURE_2D,
+    0,
+    gl.RGB,
+    textureWidth,
+    textureHeight,
+    0,
+    gl.RGB,
+    gl.FLOAT,
+    alignedTrianglesArray as Float32Array,
+  );
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.bindTexture(gl.TEXTURE_2D, null);
+
+  const u_trianglesLocation = gl.getUniformLocation(program, 'u_triangles');
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.uniform1i(u_trianglesLocation, 0);
+
+  const u_textureWidth = gl.getUniformLocation(program, 'textureWidth');
+  const u_textureHeight = gl.getUniformLocation(program, 'textureHeight');
+  gl.uniform1f(u_textureWidth, textureWidth);
+  gl.uniform1f(u_textureHeight, textureHeight);
+
+  // Midpoints texture (N_POINTS x 1)
+  const midpointsTexture = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE1);
+  gl.bindTexture(gl.TEXTURE_2D, midpointsTexture);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, N_POINTS, 1, 0, gl.RGB, gl.FLOAT, midpointsArray as Float32Array);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  const u_midpoints = gl.getUniformLocation(program, 'u_midpoints');
+  gl.uniform1i(u_midpoints, 1);
+
+  // Normals texture (N_POINTS x 1)
+  const normalsTexture = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE2);
+  gl.bindTexture(gl.TEXTURE_2D, normalsTexture);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, N_POINTS, 1, 0, gl.RGB, gl.FLOAT, normals as Float32Array);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  const u_normals = gl.getUniformLocation(program, 'u_normals');
+  gl.uniform1i(u_normals, 2);
+
+  // Points width uniform
+  const u_pointsWidth = gl.getUniformLocation(program, 'u_pointsWidth');
+  gl.uniform1f(u_pointsWidth, N_POINTS);
+
+  // Sun direction uniform location
+  const u_sun_direction = gl.getUniformLocation(program, 'u_sun_direction');
+
+  // Output framebuffer (RGBA) of size N_POINTS x 1
+  const outputTexture = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE3);
+  gl.bindTexture(gl.TEXTURE_2D, outputTexture);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, N_POINTS, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+  const framebuffer = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, outputTexture, 0);
+
+  // Fullscreen triangle buffer
+  const a_position = gl.getAttribLocation(program, 'a_position');
+  const quadBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, quadBuffer);
+  // cover full clip space (from (-1; -1) to (1; 1)):
+  const fullScreenTriangle = new Float32Array([-1, -1, 3, -1, -1, 3]);
+  gl.bufferData(gl.ARRAY_BUFFER, fullScreenTriangle, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(a_position);
+  gl.vertexAttribPointer(a_position, 2, gl.FLOAT, false, 0, 0);
+
+  gl.disable(gl.DEPTH_TEST);
+  gl.disable(gl.BLEND);
+  // set viewport size as N_POINTS x 1
+  gl.viewport(0, 0, N_POINTS, 1);
+
+  const shadedMaskScenes: Float32Array[] = [];
+
+  await timeoutForLoop(
+    0,
+    skysegmentDirectionArray.length,
+    (i) => {
+      // For the progress callback, we need to report the current vector index (i/3)
+      // out of the total number of vectors (length/3)
+      progressCallback(Math.floor(i / 3), Math.floor(skysegmentDirectionArray.length / 3));
+
+      let x = skysegmentDirectionArray[i];
+      let y = skysegmentDirectionArray[i + 1];
+      let z = skysegmentDirectionArray[i + 2];
+
+      let magnitude = Math.sqrt(x * x + y * y + z * z);
+
+      // Handle zero or near-zero magnitude
+      if (magnitude < 1e-10) {
+        // Default direction if vector is effectively zero
+        x = 0;
+        y = 0;
+        z = 1;
+      } else {
+        x = x / magnitude;
+        y = y / magnitude;
+        z = z / magnitude;
+      }
+
+      gl.uniform3fv(u_sun_direction, new Float32Array([x, y, z]));
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+      const pixelBuffer = new Uint8Array(N_POINTS * 4);
+      gl.readPixels(0, 0, N_POINTS, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixelBuffer);
+
+      // Store the result at the correct index in shadedMaskScenes (i/3 for the vector index)
+      const intensities = new Float32Array(N_POINTS);
+      for (let j = 0; j < N_POINTS; j++) {
+        const r = pixelBuffer[j * 4];
+        intensities[j] = r / 255;
+      }
+      shadedMaskScenes[Math.floor(i / 3)] = intensities;
+    },
+    3,
+  ); // Add step parameter of 3 for the loop
+
+  gl.deleteTexture(texture);
+  gl.deleteTexture(midpointsTexture);
+  gl.deleteTexture(normalsTexture);
+  gl.deleteTexture(outputTexture);
+  gl.deleteShader(vertexShader);
+  gl.deleteShader(fragmentShader);
+  gl.deleteProgram(program);
+  gl.deleteBuffer(quadBuffer);
+  return shadedMaskScenes;
+}
+
+function createShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (shader === null) {
+    return null;
+  }
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+  if (success) {
+    return shader;
+  }
+  console.error(gl.getShaderInfoLog(shader));
+  gl.deleteShader(shader);
+  return null;
+}
+
+function createProgram(
+  gl: WebGLRenderingContext,
+  vertexShader: WebGLShader | null,
+  fragmentShader: WebGLShader | null,
+): WebGLProgram {
+  const program = gl.createProgram();
+
+  if (program === null || vertexShader === null || fragmentShader === null) {
+    throw new Error('abortSimulation');
+  } else {
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    const success = gl.getProgramParameter(program, gl.LINK_STATUS);
+    if (success) {
+      return program;
+    }
+    console.error(gl.getProgramInfoLog(program));
+    gl.deleteProgram(program);
+  }
+  throw new Error('Program compilation error.');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * as colormaps from './colormaps';
 export { ShadingScene } from './main';
 export { HeadlessShadingScene } from './headless/headlessShadingScene';
+export { runShadingSceneHeadlessChromium } from './headless/headlessBrowser';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * as colormaps from './colormaps';
 export { ShadingScene } from './main';
+export { HeadlessShadingScene } from './headless/headlessShadingScene';

--- a/src/rayTracingWebGL.ts
+++ b/src/rayTracingWebGL.ts
@@ -12,6 +12,7 @@ import { timeoutForLoop } from './utils';
  * @param trianglesArray flattened Mx9 array with M the number of shading triangles
  * @param skysegmentDirectionArray flattened Sx3 array with S being the number of sky segments (normalized!)
  * @param progressCallback flattened Callback indicating the progress
+ * @param gl a WebGL2 context that shall be used.
  * @returns shadedMaskScenes: NxS array containing the dot product of the direction vector of the skysegment and the normal of the midpoint
  */
 export async function rayTracingWebGL(
@@ -20,14 +21,17 @@ export async function rayTracingWebGL(
   trianglesArray: TypedArray,
   skysegmentDirectionArray: Float32Array,
   progressCallback: (progress: number, total: number) => void,
+  gl?: WebGL2RenderingContext | null,
 ): Promise<Float32Array[] | null> {
   const N_TRIANGLES = trianglesArray.length / 9;
   const width = midpointsArray.length / 3; // Change this to the number of horizontal points in the grid
   const N_POINTS = width;
 
-  const gl = document.createElement('canvas').getContext('webgl2');
   if (!gl) {
-    throw new Error('Browser does not support WebGL2');
+    gl = document.createElement('canvas').getContext('webgl2');
+  }
+  if (!gl) {
+    throw new Error('WebGL2 is not supported');
   }
 
   // Vertex shader code

--- a/src/rayTracingWebGLWrapper.ts
+++ b/src/rayTracingWebGLWrapper.ts
@@ -1,0 +1,47 @@
+import { TypedArray } from 'three';
+import { rayTracingWebGL } from './rayTracingWebGL';
+import { rayTracingWebGL1Headless } from './headless/rayTracingWebGL1Headless';
+
+/**
+ * A wrapper for rayTracingWebGL and rayTracingWebGL1Headless.
+ * This allows using either browser-based or headless WebGL contexts
+ * Automatically detects WebGL version and uses appropriate implementation
+ */
+export async function rayTracingWebGLWrapper(
+  midpointsArray: TypedArray,
+  normals: TypedArray,
+  trianglesArray: TypedArray,
+  skysegmentDirectionArray: Float32Array,
+  progressCallback: (progress: number, total: number) => void,
+  gl?: WebGLRenderingContext | WebGL2RenderingContext | null,
+): Promise<Float32Array[] | null> {
+  if (!gl) {
+    // We expect simshady to run in the browser
+    return rayTracingWebGL(midpointsArray, normals, trianglesArray, skysegmentDirectionArray, progressCallback);
+  } else {
+    // Provided GL context means we are running in a headless environment
+
+    // Check if we have WebGL2 support
+    const isWebGL2 = 'createVertexArray' in gl;
+    if (isWebGL2) {
+      // Use WebGL2 implementation
+      return rayTracingWebGL(
+        midpointsArray,
+        normals,
+        trianglesArray,
+        skysegmentDirectionArray,
+        progressCallback,
+        gl as WebGL2RenderingContext,
+      );
+    } else {
+      return rayTracingWebGL1Headless(
+        midpointsArray,
+        normals,
+        trianglesArray,
+        skysegmentDirectionArray,
+        progressCallback,
+        gl as WebGLRenderingContext,
+      );
+    }
+  }
+}

--- a/src/types/gl.d.ts
+++ b/src/types/gl.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Type declarations for the 'gl' package (headless-gl)
+ * Attributes are a union of the official WebGL context attributes and a headless-gl specific attribute.
+ * https://registry.khronos.org/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES
+ * https://github.com/stackgl/headless-gl?tab=readme-ov-file#expiremental-webgl2-support
+ */
+
+declare module 'gl' {
+  type WebGLPowerPreference = 'default' | 'high-performance' | 'low-power';
+  interface ContextAttributes {
+    createWebGL2Context?: boolean;
+    alpha?: boolean;
+    depth?: boolean;
+    stencil?: boolean;
+    antialias?: boolean;
+    premultipliedAlpha?: boolean;
+    preserveDrawingBuffer?: boolean;
+    powerPreference?: WebGLPowerPreference;
+    failIfMajorPerformanceCaveat?: boolean;
+    desynchronized?: boolean;
+  }
+
+  function createGL(
+    width: number,
+    height: number,
+    contextAttributes?: ContextAttributes,
+  ): WebGLRenderingContext | WebGL2RenderingContext;
+
+  export = createGL;
+}

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -4,6 +4,7 @@ import { rayTracingWebGLWrapper } from '../src/rayTracingWebGLWrapper';
 import { createHeadlessGL } from '../src/headless/createHeadlessGL';
 import { solarData } from './data';
 import { BufferGeometry, Float32BufferAttribute } from 'three';
+import { runShadingSceneHeadlessChromium } from '../src';
 
 describe('Headless WebGL Context Creation', () => {
   test('createHeadlessGL creates a WebGL context with default options', async () => {
@@ -74,5 +75,15 @@ describe('Headless Shading Scene Functionality', () => {
     const result = await scene.calculate();
     scene.dispose();
     expect(result).toBeDefined;
+  });
+});
+
+describe('Headless Browser', () => {
+  test('check browser functionality', async () => {
+    const sim = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const shade = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+
+    const result = await runShadingSceneHeadlessChromium(sim, shade, solarData);
+    expect(result).toBeDefined();
   });
 });

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { HeadlessShadingScene } from '../src';
+import { rayTracingWebGLWrapper } from '../src/rayTracingWebGLWrapper';
+import { createHeadlessGL } from '../src/headless/createHeadlessGL';
+import { solarData } from './data';
+import { BufferGeometry, Float32BufferAttribute } from 'three';
+
+describe('Headless WebGL Context Creation', () => {
+  test('createHeadlessGL creates a WebGL context with default options', async () => {
+    const gl = await createHeadlessGL();
+    expect(gl).toBeDefined();
+  });
+
+  test('check for OES_texture_float', async () => {
+    const gl = await createHeadlessGL();
+    const hasTextureFloat = !!gl.getExtension('OES_texture_float');
+    expect(hasTextureFloat).toBe(true);
+    expect(gl).toBeDefined();
+  });
+
+  test('createHeadlessGL respects custom options', async () => {
+    const size = 256;
+    const options = {
+      width: size,
+      height: size,
+      preserveDrawingBuffer: true,
+      antialias: false,
+    };
+
+    const gl = await createHeadlessGL(options);
+    expect(gl).toBeDefined();
+    expect(gl.drawingBufferHeight).toBe(size);
+    expect(gl.drawingBufferWidth).toBe(size);
+  });
+});
+
+describe('rayTracingWebGLHeadless Function', () => {
+  test('ray tracing functionality', async () => {
+    const gl = await createHeadlessGL();
+    const midpoints = new Float32Array([0, 0, 0]);
+    const normals = new Float32Array([0, 0, 1]);
+    const triangles = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const skySegments = new Float32Array([0, 0, 1, 1, 0, 0]);
+    const progressCallback = vi.fn();
+    const result = await rayTracingWebGLWrapper(midpoints, normals, triangles, skySegments, progressCallback, gl);
+
+    expect(result).toBeDefined();
+  });
+});
+
+describe('Headless Shading Scene Functionality', () => {
+  let scene: HeadlessShadingScene;
+
+  beforeEach(() => {
+    scene = new HeadlessShadingScene();
+  });
+
+  test('dispose cleans up resources properly', async () => {
+    const gl = await createHeadlessGL();
+    scene.setWebGLContext(gl);
+    scene.dispose();
+    // if createBuffer throws an error then WebGL context has been disposed
+    expect(() => gl.createBuffer()).toThrow();
+  });
+
+  test('check end to end works properly', async () => {
+    const sim = new BufferGeometry();
+    sim.setAttribute('position', new Float32BufferAttribute(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 3));
+    const shade = new BufferGeometry();
+    shade.setAttribute('position', new Float32BufferAttribute(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 3));
+    scene.addSimulationGeometry(sim);
+    scene.addShadingGeometry(shade);
+    scene.addSolarIrradiance(solarData);
+    const result = await scene.calculate();
+    scene.dispose();
+    expect(result).toBeDefined;
+  });
+});

--- a/tests/rayTracingWebGL1Headless.test.ts
+++ b/tests/rayTracingWebGL1Headless.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+import { rayTracingWebGL1Headless } from '../src/headless/rayTracingWebGL1Headless';
+import { createHeadlessGL } from '../src/headless/createHeadlessGL';
+
+let gl: WebGLRenderingContext;
+
+beforeAll(async () => {
+  gl = await createHeadlessGL({ createWebGL2Context: false, width: 64, height: 64 });
+});
+
+function expectCloseArray(actual: Float32Array, expected: number[], eps = 0.0) {
+  expect(actual.length).toBe(expected.length);
+  for (let i = 0; i < expected.length; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(eps);
+  }
+}
+
+function makeFloat32(arr: number[]): Float32Array {
+  return new Float32Array(arr);
+}
+
+function makeTriangle(u: [number, number, number], v: [number, number, number], w: [number, number, number]): number[] {
+  return [...u, ...v, ...w];
+}
+
+describe('rayTracingWebGL1Headless - intensity without occlusion', () => {
+  test('aligned: normal (+Z) and sun (+Z) -> 1.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    const triangles = makeFloat32(makeTriangle([-10, -10, -1], [10, -10, -1], [0, 10, -1])); // behind the point
+    const sunDirs = makeFloat32([0, 0, 1]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expect(res!.length).toBe(1);
+    expectCloseArray(res![0], [1.0]);
+  });
+
+  test('orthogonal: normal (+Z) and sun (+X) -> 0.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    const triangles = makeFloat32(makeTriangle([-10, -10, -1], [10, -10, -1], [0, 10, -1]));
+    const sunDirs = makeFloat32([1, 0, 0]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expectCloseArray(res![0], [0.0]);
+  });
+
+  test('opposite: normal (+Z) and sun (-Z) -> 1.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    // Place occluder away from the -Z ray (put it at +Z)
+    const triangles = makeFloat32(makeTriangle([-10, -10, 1], [10, -10, 1], [0, 10, 1]));
+    const sunDirs = makeFloat32([0, 0, -1]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expectCloseArray(res![0], [1.0]);
+  });
+
+  test('60 deg angle: normal (+Z) and sun 60 deg from Z+  -> 0.5', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    const triangles = makeFloat32(makeTriangle([-10, -10, -1], [10, -10, -1], [0, 10, -1]));
+    // x = sin(60°); z = cos(60°)
+    const dir = [Math.sqrt(3) / 2, 0, 0.5];
+    const sunDirs = makeFloat32(dir);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expectCloseArray(res![0], [0.5], 0.01);
+  });
+});
+
+describe('rayTracingWebGL1Headless - intensity with occlusion', () => {
+  test('occluder between point and sun → 0.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    // big triangle at z=+0.5 covering the ray from origin to +Z
+    const triangles = makeFloat32(makeTriangle([-10, -10, 0.5], [10, -10, 0.5], [0, 10, 0.5]));
+    const sunDirs = makeFloat32([0, 0, 1]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expectCloseArray(res![0], [0.0]);
+  });
+
+  test('occluder below point → 1.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    const triangles = makeFloat32(makeTriangle([-10, -10, -0.5], [10, -10, -0.5], [0, 10, -0.5]));
+    const sunDirs = makeFloat32([0, 0, 1]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expectCloseArray(res![0], [1.0]);
+  });
+
+  test('occluder off-axis → 1.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    // triangle at z=+0.5 but far on +X so the +Z ray misses it
+    const triangles = makeFloat32(makeTriangle([10, -10, 0.5], [12, -10, 0.5], [10, 10, 0.5]));
+    const sunDirs = makeFloat32([0, 0, 1]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expectCloseArray(res![0], [1.0]);
+  });
+});
+
+describe('rayTracingWebGL1Headless - multiple points', () => {
+  test('two points with different normals: (+X) and (+Z) -> 0.0 and 1.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0, 0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1, 1, 0, 0]);
+    const triangles = makeFloat32(makeTriangle([-10, -10, -1], [10, -10, -1], [0, 10, -1]));
+    const sunDirs = makeFloat32([0, 0, 1]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expectCloseArray(res![0], [1.0, 0.0]);
+  });
+
+  test('10 points plane, uniform normal', async () => {
+    const N = 10;
+    const midpoints = new Float32Array(new Array(N).fill(0).flatMap((_, index, __) => [index, 0, 0]));
+    const normals = new Float32Array(new Array(N).fill(0).flatMap(() => [0, 0, 1]));
+    const triangles = makeFloat32(makeTriangle([-10, -10, -1], [10, -10, -1], [0, 10, -1]));
+    const sunDirs = makeFloat32([0, 0, 1]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res![0].length).toBe(N);
+    expectCloseArray(res![0], new Array(N).fill(1.0));
+  });
+});
+
+describe('rayTracingWebGL1Headless - multiple sun directions', () => {
+  test('two sun directions: normal (+Z) and sun (+Z) and (+X) -> 1.0 and 0.0', async () => {
+    const midpoints = makeFloat32([0, 0, 0]);
+    const normals = makeFloat32([0, 0, 1]);
+    const triangles = makeFloat32(makeTriangle([-10, -10, -1], [10, -10, -1], [0, 10, -1]));
+    const sunDirs = makeFloat32([0, 0, 1, 1, 0, 0]);
+
+    const res = await rayTracingWebGL1Headless(midpoints, normals, triangles, sunDirs, () => {}, gl);
+    expect(res).toBeTruthy();
+    expect(res!.length).toBe(2);
+    expectCloseArray(res![0], [1.0]); // +Z
+    expectCloseArray(res![1], [0.0]); // +X
+  });
+});


### PR DESCRIPTION
Hi @FlorianK13 ,

I have now implemented two approaches for using simshady headless. We have already discussed the first one, namely using headless-gl. However, since WebGL2 for headless-gl is only in an experimental state and does not work at all with WebGL2 on my local machine, I had to rewrite some of rayTracingWebGL to be compatible with WebGL1. In doing so, I tried to stay as close as possible to the original implementation. 

The primary problem I encountered is the lack of the transform feedback feature in WebGL 1. Instead, I use a GPGPU “trick” in which an auxiliary triangle is used as a render target to parallelize the actual calculations. The auxiliary triangle has a size of N times 1, where N is the number of midpoints of the simulation geometry. The auxiliary triangle triggers the vertex shader calculation once, and for each pixel, aka each midpoint, the old vertex shader computation (slightly modified to work with WEbGL1) is now triggered once as a fragment shader. We then write the results to the frame buffer.

The second solution is using puppeteer. Puppeteer uses Chrome for testing and chrome-headless-shell. This allows the original simshady ShadingScene implementation to be used. Theoretically, Firefox can also be used. The advantage of this approach is that no customized WebGL1 solution neither headless-gl is required. The standard shading scene can be used. 

The first commit is for the headless-gl solution and the second one is for the headless browser approach.